### PR TITLE
Check for $GOPATH

### DIFF
--- a/interfacer/contrib/setup_go.sh
+++ b/interfacer/contrib/setup_go.sh
@@ -4,6 +4,12 @@ set -e
 # Install `dep` the current defacto dependency for Golang
 GOLANG_DEP_VERSION=0.3.2
 dep_url=https://github.com/golang/dep/releases/download/v$GOLANG_DEP_VERSION/dep-linux-amd64
+
+if [ -z $GOPATH ]; then
+  echo '$GOPATH is not set, aborting'
+  exit 1
+fi
+
 curl -L -o $GOPATH/bin/dep $dep_url
 chmod +x $GOPATH/bin/dep
 


### PR DESCRIPTION
The shell script in `interfacer/contrib/setup_go.sh` expands the `$GOPATH` variable to download a script to `$GOPATH/bin`. However, if `$GOPATH` is not set, that expands to `/bin`. If the script is run with root privileges (accidentally), this will download a "strange" executable to /bin, which
is supposed to be for system executables. If it is run without root privileges, it gives an (unclear) error about permissions. This commit checks if `$GOPATH` exists. If it `$GOPATH` does not exist, it exits with error code 1.