### PR TITLE
TTY-based scrolling

### DIFF
--- a/interfacer/test/tty/setup.go
+++ b/interfacer/test/tty/setup.go
@@ -76,6 +76,13 @@ func Keyboard(keys string) {
 	}
 }
 
+// SpecialMouse injects a special mouse event into the TTY. See Tcell's `mouse.go` file for all
+// the available special mouse values.
+func SpecialMouse(mouse tcell.ButtonMask) {
+	simScreen.InjectMouse(0, 0, mouse, tcell.ModNone)
+	time.Sleep(100 * time.Millisecond)
+}
+
 func waitForNextFrame() {
 	// Need to wait so long because the frame rate is currently so slow
 	// TODO: Reduce the wait when the FPS is higher

--- a/interfacer/test/tty/tty_test.go
+++ b/interfacer/test/tty/tty_test.go
@@ -39,6 +39,12 @@ var _ = Describe("Showing a basic webpage", func() {
 				Expect("Another").To(BeInFrameAt(0, 0))
 			})
 
+			It("should scroll the page by one line using the mouse", func() {
+				SpecialMouse(tcell.WheelDown)
+				SpecialMouse(tcell.WheelDown)
+				Expect("meal,▄originating▄in▄").To(BeInFrameAt(12, 11))
+			})
+
 			It("should scroll the page by one line", func() {
 				SpecialKey(tcell.KeyDown)
 				Expect("meal,▄originating▄in▄").To(BeInFrameAt(12, 11))

--- a/webext/src/dom/commands_mixin.js
+++ b/webext/src/dom/commands_mixin.js
@@ -127,11 +127,11 @@ export default MixinBase =>
           break;
         case 256:
           console.log("ScrollUp")
-          window.scrollBy(0, -1)
+          this._handleScroll(0, -1)
           break;
         case 512:
           console.log("ScrollDown")
-          window.scrollBy(0, 1)
+          this._handleScroll(0, 1)
           break;
       }
     }

--- a/webext/src/dom/commands_mixin.js
+++ b/webext/src/dom/commands_mixin.js
@@ -125,6 +125,14 @@ export default MixinBase =>
           }
           this._mousedown = false;
           break;
+        case 256:
+          console.log("ScrollUp")
+          window.scrollBy(0, -1)
+          break;
+        case 512:
+          console.log("ScrollDown")
+          window.scrollBy(0, 1)
+          break;
       }
     }
 

--- a/webext/src/dom/commands_mixin.js
+++ b/webext/src/dom/commands_mixin.js
@@ -125,14 +125,6 @@ export default MixinBase =>
           }
           this._mousedown = false;
           break;
-        case 256:
-          console.log("ScrollUp")
-          this._handleScroll(0, -1)
-          break;
-        case 512:
-          console.log("ScrollDown")
-          this._handleScroll(0, 1)
-          break;
       }
     }
 


### PR DESCRIPTION
I'm not totally sure this will end up being practical, but it works locally. I've tried passing scroll events to the Firefox extension and having the scrolling done there, but it was too slow.

Addresses #157.