### PR TITLE
Issue 172

### DIFF
--- a/contrib/release_if_new_version.sh
+++ b/contrib/release_if_new_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/interfacer/contrib/build_browsh.sh
+++ b/interfacer/contrib/build_browsh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is for building a production version of Browsh.
 # To build Browsh during development see:

--- a/interfacer/contrib/build_browsh.sh
+++ b/interfacer/contrib/build_browsh.sh
@@ -12,7 +12,7 @@
 
 set -e
 
-INTERFACER_ROOT=$(readlink -m "$( cd "$(dirname "$0")" ; pwd -P )"/../)
+INTERFACER_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && cd ../ && pwd )"
 cd $INTERFACER_ROOT
 
 # Install `dep` the current defacto dependency manager for Golang

--- a/interfacer/contrib/get_browsh_version.sh
+++ b/interfacer/contrib/get_browsh_version.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel)

--- a/interfacer/contrib/setup_dep.sh
+++ b/interfacer/contrib/setup_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Install `dep` the current defacto dependency for Golang

--- a/interfacer/contrib/setup_firefox.sh
+++ b/interfacer/contrib/setup_firefox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/interfacer/contrib/upx_compress_binary.sh
+++ b/interfacer/contrib/upx_compress_binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 shopt -s extglob
 

--- a/interfacer/contrib/xpi2bin.sh
+++ b/interfacer/contrib/xpi2bin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 INTERFACER_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && cd ../ && pwd )"

--- a/interfacer/contrib/xpi2bin.sh
+++ b/interfacer/contrib/xpi2bin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-INTERFACER_ROOT=$(readlink -m "$( cd "$(dirname "$0")" ; pwd -P )"/../)
+INTERFACER_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && cd ../ && pwd )"
 
 go-bindata -version
 go-bindata \

--- a/webext/contrib/bundle_webextension.sh
+++ b/webext/contrib/bundle_webextension.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Convert the Browsh webextension into embedable binary data so that we can
 # distribute Browsh as a single static binary.
 

--- a/webext/contrib/firefoxheadless.sh
+++ b/webext/contrib/firefoxheadless.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$1" = "kill" ]]; then
   kill $(ps aux|grep headless|grep 'profile /tmp'| tr -s ' ' | cut -d ' ' -f2)

--- a/webext/contrib/setup_node.sh
+++ b/webext/contrib/setup_node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! type "nvm" > /dev/null; then
   rm -rf ~/.nvm


### PR DESCRIPTION
Closes #172 .
Improves the portability of browsh build scripts. I've tested this on Mac. Will test on Ubuntu prior to merging in. 
Could @vext01 test this out on OpenBSD and let me know if this helps?