### PR TITLE
Replace firefoxheadless.sh with soft kill

### DIFF
--- a/interfacer/src/browsh/raw_text_server.go
+++ b/interfacer/src/browsh/raw_text_server.go
@@ -80,6 +80,10 @@ func HTTPServerStart() {
 	}
 }
 
+func HTTPServerStop() {
+	quitFirefox()
+}
+
 func setupRateLimiter() *stdlib.Middleware {
 	rate, err := limiter.NewRateFromFormatted(viper.GetString("http-server.rate-limit"))
 	if err != nil {

--- a/interfacer/test/http-server/setup.go
+++ b/interfacer/test/http-server/setup.go
@@ -72,5 +72,5 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	browsh.Shell(rootDir + "/webext/contrib/firefoxheadless.sh kill")
+	browsh.HTTPServerStop()
 })

--- a/interfacer/test/tty/setup.go
+++ b/interfacer/test/tty/setup.go
@@ -225,5 +225,5 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	browsh.Shell(rootDir + "/webext/contrib/firefoxheadless.sh kill")
+	browsh.HTTPServerStop()
 })

--- a/webext/contrib/firefoxheadless.sh
+++ b/webext/contrib/firefoxheadless.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-if [[ "$1" = "kill" ]]; then
-  kill $(ps aux|grep headless|grep 'profile /tmp'| tr -s ' ' | cut -d ' ' -f2)
-else
-  FIREFOX_BIN=${FIREFOX:-firefox}
-  $FIREFOX_BIN --headless "$@"
-fi


### PR DESCRIPTION
- Fixes #61 (removed `firefoxheadless.sh`, save PID)
- Kills Firefox softly in tests instead of killing the process

I'm still having a little trouble with running my build which might be related to using WSL (I can't run master either)... Will test again later on Linux.