### PR TITLE
Update: non-option argument instead of --startup-url

### DIFF
--- a/interfacer/src/browsh/browsh.go
+++ b/interfacer/src/browsh/browsh.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -194,10 +193,7 @@ func noFlagParse() {
 	var validURI []string
 	if pflag.NArg() != 0 {
 		for i := 0; i < len(pflag.Args()); i++ {
-			u, _ := url.ParseRequestURI(pflag.Args()[i])
-			if u != nil {
-				validURI = append(validURI, pflag.Args()[i])
-			}
+			validURI = append(validURI, pflag.Args()[i])
 		}
 	}
 	viper.SetDefault("validURI", validURI)

--- a/interfacer/src/browsh/browsh.go
+++ b/interfacer/src/browsh/browsh.go
@@ -189,9 +189,7 @@ func ttyEntry() {
 	TTYStart(realScreen)
 }
 
-// MainEntry decides between running Browsh as a CLI app or as an HTTP web server
-func MainEntry() {
-	pflag.Parse()
+func noFlagParse() {
 	// validURI contains array of valid user inputted links.
 	var validURI []string
 	if pflag.NArg() != 0 {
@@ -203,6 +201,12 @@ func MainEntry() {
 		}
 	}
 	viper.SetDefault("validURI", validURI)
+}
+
+// MainEntry decides between running Browsh as a CLI app or as an HTTP web server
+func MainEntry() {
+	pflag.Parse()
+	noFlagParse()
 	Initialise()
 	if viper.GetBool("version") {
 		println(browshVersion)

--- a/interfacer/src/browsh/browsh.go
+++ b/interfacer/src/browsh/browsh.go
@@ -192,17 +192,17 @@ func ttyEntry() {
 // MainEntry decides between running Browsh as a CLI app or as an HTTP web server
 func MainEntry() {
 	pflag.Parse()
-	// validURL contains array of valid user inputted links.
-	var validURL []string
+	// validURI contains array of valid user inputted links.
+	var validURI []string
 	if pflag.NArg() != 0 {
 		for i := 0; i < len(pflag.Args()); i++ {
 			u, _ := url.ParseRequestURI(pflag.Args()[i])
 			if u != nil {
-				validURL = append(validURL, pflag.Args()[i])
+				validURI = append(validURI, pflag.Args()[i])
 			}
 		}
 	}
-	viper.SetDefault("validURL", validURL)
+	viper.SetDefault("validURI", validURI)
 	Initialise()
 	if viper.GetBool("version") {
 		println(browshVersion)

--- a/interfacer/src/browsh/comms.go
+++ b/interfacer/src/browsh/comms.go
@@ -147,12 +147,12 @@ func webSocketServer(w http.ResponseWriter, r *http.Request) {
 	}
 	// For some reason, using Firefox's CLI arg `--url https://google.com` doesn't consistently
 	// work. So we do it here instead.
-	validURL := viper.GetStringSlice("validURL")
-	if len(validURL) == 0 {
+	validURI := viper.GetStringSlice("validURI")
+	if len(validURI) == 0 {
 		sendMessageToWebExtension("/new_tab," + viper.GetString("startup-url"))
 	} else {
-		for i := 0; i < len(validURL); i++ {
-			sendMessageToWebExtension("/new_tab," + validURL[i])
+		for i := 0; i < len(validURI); i++ {
+			sendMessageToWebExtension("/new_tab," + validURI[i])
 		}
 	}
 }


### PR DESCRIPTION
This pull request should complete #205 , Main updates:
- Removed URL validation to accept links more freely. 
- Is able to accept strings to google search. ie. `browsh "browsh documentation"` will open a google search of the string.