### PR TITLE
Update to Firefox 66.0.4 to fix addon cert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 
 addons:
   # Use the full version number with ".0" if needed. This value is scraped by setup scripts.
-  firefox: "63.0"
+  firefox: "66.0.4"
   apt:
     packages:
       - rpm

--- a/interfacer/src/browsh/version.go
+++ b/interfacer/src/browsh/version.go
@@ -1,3 +1,3 @@
 package browsh
 
-var browshVersion = "1.5.0"
+var browshVersion = "1.5.1"


### PR DESCRIPTION
In response to Mozilla's recent expired addon certificate issue we need to upgrade Firefox. The certificate is *local* to the browser, so the browser itself needs to be updated.