### PR TITLE
default to https for donate

### DIFF
--- a/webext/src/dom/serialise_mixin.js
+++ b/webext/src/dom/serialise_mixin.js
@@ -103,7 +103,7 @@ export default MixinBase =>
       donating =
         this._raw_mode_type === "raw_text_html"
           ? '<a href="https://www.brow.sh/donate">donating</a>'
-          : "brow.sh/donate";
+          : "https://brow.sh/donate";
       return (
         "\nPlease consider " +
         donating +


### PR DESCRIPTION
Just installed this, I'm super hyped !!!!

when I clicked the donate link at the bottom, my browser opened to the http version of the site

![Screen Shot 2020-06-17 at 9 40 58 PM](https://user-images.githubusercontent.com/6182700/84971870-4c285d80-b0e3-11ea-96e8-8a3c71dee300.png)

I did a grep and found this line, I figured adding the full protocol would address this issue. Happy to test this but my grep only gave back this file so if more testing is needed point me in the right direction and I'll be glad to add some mocha for it or whatever