### PR TITLE
Improved CLI's flags and changed help page

### DIFF
--- a/interfacer/src/browsh/browsh.go
+++ b/interfacer/src/browsh/browsh.go
@@ -204,10 +204,20 @@ func MainEntry() {
 	}
 	viper.SetDefault("validURL", validURL)
 	Initialise()
-	if viper.GetBool("version") {
+	
+	// Print version if asked and exit
+	if (viper.GetBool("version") || viper.GetBool("v")) {
 		println(browshVersion)
 		os.Exit(0)
 	}
+	
+	// Print name if asked and exit
+	if (viper.GetBool("name") || viper.GetBool("n")) {
+		println("Browsh")
+		os.Exit(0)
+	}
+	
+	// Decide whether to run in http-server-mode or CLI app
 	if viper.GetBool("http-server-mode") {
 		HTTPServerStart()
 	} else {

--- a/interfacer/src/browsh/config.go
+++ b/interfacer/src/browsh/config.go
@@ -24,6 +24,7 @@ var (
 	_ = pflag.Bool("firefox.with-gui", false, "Don't use headless Firefox")
 	_ = pflag.Bool("firefox.use-existing", false, "Whether Browsh should launch Firefox or not")
 	_ = pflag.Bool("monochrome", false, "Start browsh in monochrome mode")
+	_ = pflag.Bool("name", false, "Print out the name: Browsh")
 )
 
 func getConfigNamespace() string {


### PR DESCRIPTION
# Improved CLI's flags and changed help page
I have added in the name flag for printing out the name of the application and also improved the version flag by adding in an alias. The alias for the name flag is the n flag. The help page has been updated accordingly.