### PR TITLE
Add  browsh to PATH in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ WORKDIR /app
 
 COPY --from=build /go-home/src/browsh/interfacer/browsh /app/browsh
 
+# Add browsh on PATH
+RUN ln -s /app/browsh /usr/local/bin/browsh
+
 RUN install_packages \
       xvfb \
       libgtk-3-0 \
@@ -76,5 +79,4 @@ RUN TERM=xterm script \
   >/dev/null & \
   sleep 10
 
-CMD ["/app/browsh"]
-
+CMD [ "browsh" ]


### PR DESCRIPTION
People can't guess where the binary is stored. So they could do:

```sh-session
docker run --rm -it browsh/browsh browsh --startup-url https://google.com
```

rather than:

```sh-session
docker run --rm -it browsh/browsh /app/browsh --startup-url https://google.com
```