### PR TITLE
Fix #254 for goreleser-homebrew's tap/artefacts

### DIFF
--- a/interfacer/src/.goreleaser.yml
+++ b/interfacer/src/.goreleaser.yml
@@ -22,8 +22,6 @@ archive:
   format_overrides:
     - goos: windows
       format: binary
-    - goos: linux
-      format: binary
     - goos: freebsd
       format: binary
     - goos: openbsd


### PR DESCRIPTION
PR for GitHub Releases using this example:(https://github.com/bottlerocketlabs/localpod/blob/master/.goreleaser.yml).
The resulted linux's artifact for homebrew must be packaged accordingly to darwin's artifact for homebrew (gzipped).
PR affects https://github.com/browsh-org/homebrew-browsh repository