### PR TITLE
Fix Mac Build Environment Documentation

### DIFF
--- a/contrib/setup_mac_build_environment.md
+++ b/contrib/setup_mac_build_environment.md
@@ -76,7 +76,7 @@ $ npx webpack --watch
 
 ```sh
 $ # the dist folder is created in the first terminal
-$ cd "$GOPATH/browsh/webext/dist"
+$ cd "$GOPATH/src/browsh/webext/dist"
 $ # create a dist folder inside the webext folder.
 $ npx webpack --watch
 ```
@@ -84,7 +84,7 @@ $ npx webpack --watch
 ### Terminal 3 (Displays Browsh)
 
 ```sh
-$ cd "$GOPATH/browsh"
-$ go run ./interfacer/src/main.go --firefox.use-existing --debug
+$ cd "$GOPATH/src/browsh/interfacer"
+$ go run ./cmd/browsh/main.go --firefox.use-existing --debug
 ```
 


### PR DESCRIPTION
- commited: small fixes to paths that I needed to do locally
- it looked like I was missing `go-bindata` during the `build_browsh.sh` process ("go-bindata: command not found"), but it might have been because `$GOPATH/bin` was not part of `$PATH`
- the "second" terminal that runs `npx webpack --watch` within `src/browsh/webext/dist` is throwing an error right now:

```
ERROR in ENOENT: no such file or directory, open '../interfacer/src/browsh/version.go'
```

I believe that this is due to the path to `version.go` defined [here](https://github.com/browsh-org/browsh/blob/master/webext/webpack.config.js#L37) which cannot be the same for both terminals where `npx webpack --watch` are running (since they are running from different directories)
- I'm a bit confused right now as to who's running what -- from what I understand, `browsh.xpi` is downloaded from the github releases in `build_browsh.sh`. So probably that my (single working) `npx webpack --watch` (i.e. "Terminal 1") is not doing much right now, correct..? Thanks!