### PR TITLE
feat: github action for cross-compiling releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,17 +8,18 @@ jobs:
       GOBIN: ${{ github.workspace }}/bin
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup go
         uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
-      - name: Install go-bindata
-        run: go install github.com/kevinburke/go-bindata/go-bindata@latest
-      - name: Build
+      - name: Pre-build
         run: ./interfacer/contrib/build_browsh.sh
+      - name: Build
+        working-directory: ./interfacer
+        run: go build ./cmd/browsh
       - name: Test
         run: ./interfacer/browsh --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+on:
+  release:
+    types: [created]
+
+jobs:
+  releases-matrix:
+    name: Release Browsh
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64, arm64]
+        exclude:
+          - goarch: "386"
+            goos: darwin
+          - goarch: arm64
+            goos: windows
+    steps:
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.29
+      with:
+        pre_command: "./interfacer/contrib/build_browsh.sh"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: 1.18
+        project_path: "./interfacer/cmd/browsh"
+        binary_name: "browsh"
+        extra_files: LICENSE README.md

--- a/interfacer/contrib/build_browsh.sh
+++ b/interfacer/contrib/build_browsh.sh
@@ -37,4 +37,4 @@ XPI_FILE=$xpi_file BIN_FILE=$destination \
   $INTERFACER_ROOT/contrib/xpi2bin.sh
 
 # The actual build iteself
-go build ./cmd/browsh
+# go build ./cmd/browsh


### PR DESCRIPTION
This will cross-compile binaries every time a release is created 

Action test run: https://github.com/tormodatt/browsh/actions/runs/2594843467

Result: https://github.com/tormodatt/browsh/releases/tag/v1.6.5-alpha5

Maybe a release could be created so that we can add arm64 to the homebrew formula @tombh ?