### PR TITLE
Support for arm64 Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ WORKDIR $BASE
 RUN /build/ctl.sh install_golang $BASE
 RUN /build/ctl.sh build_browsh_binary $BASE
 
-# Install firefox
-RUN /build/ctl.sh install_firefox
-
-
 ###########################
 # Actual final Docker image
 ###########################
@@ -47,7 +43,6 @@ ENV HOME=/app
 WORKDIR $HOME
 
 COPY --from=build /go-home/src/browsh/interfacer/browsh /app/bin/browsh
-COPY --from=build /tmp/firefox /app/bin/firefox
 
 RUN install_packages \
       xvfb \
@@ -57,7 +52,8 @@ RUN install_packages \
       libdbus-glib-1-2 \
       procps \
       libasound2 \
-      libxtst6
+      libxtst6 \
+      firefox-esr
 
 # Block ads, etc. This includes porn just because this image is also used on the
 # public SSH demo: `ssh brow.sh`.

--- a/scripts/misc.bash
+++ b/scripts/misc.bash
@@ -51,10 +51,12 @@ function install_golang() {
 	local version && version=$(parse_golang_version_from_go_mod "$path")
 	[ "$GOPATH" = "" ] && _panic "GOPATH not set"
 	[ "$GOROOT" = "" ] && _panic "GOROOT not set"
+	GOARCH=$(uname -m)
+	[[ $GOARCH == aarch64 ]] && GOARCH=arm64
 	echo "Installing Golang v$version... to $GOROOT"
 	curl -L \
 		-o go.tar.gz \
-		https://dl.google.com/go/go"$version".linux-amd64.tar.gz
+		https://dl.google.com/go/go"$version".linux-"$GOARCH".tar.gz
 	mkdir -p "$GOPATH"/bin
 	mkdir -p "$GOROOT"
 	tar -C "$GOROOT/.." -xzf go.tar.gz


### PR DESCRIPTION
This MR adds support to allow non-amd64 docker images. Fixes   #374 

Testbed details:
```
samveen@devbox-4b:~/browsh $ grep PRETTY /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
samveen@devbox-4b:~/browsh $ grep -E '^Hard|^Rev|^Mod' /proc/cpuinfo
Hardware	: BCM2835
Revision	: b03112
Model		: Raspberry Pi 4 Model B Rev 1.2
samveen@devbox-4b:~/browsh $ uname -a
Linux devbox-4b.cluster.samveen.in 5.15.84-v8+ #1613 SMP PREEMPT Thu Jan 5 12:03:08 GMT 2023 aarch64 GNU/Linux
```