### PR TITLE
fix: Golang install: use "amd64" for "x86_64"

### DIFF
--- a/scripts/bundling.bash
+++ b/scripts/bundling.bash
@@ -81,11 +81,13 @@ function _rename_built_xpi() {
 function bundle_production_webextension() {
 	local version && version=$(browsh_version)
 	local base='https://github.com/browsh-org/browsh/releases/download'
-	local release_url="$base/v$version/browsh-$version-an.fx.xpi"
+	local release_url="$base/v$version/browsh-$version.xpi"
 	echo "Downloading webextension from: $release_url"
-	local size && size=$(wc -c <"$XPI_PATH")
 	curl -L -o "$XPI_PATH" "$release_url"
+	local size && size=$(wc -c <"$XPI_PATH")
 	if [ "$size" -lt 500 ]; then
+		echo "XPI size seems too small: $size"
 		_panic "Problem downloading latest webextension XPI"
 	fi
+	cp -a "$XPI_PATH" "$(versioned_xpi_file)"
 }

--- a/scripts/misc.bash
+++ b/scripts/misc.bash
@@ -53,10 +53,12 @@ function install_golang() {
 	[ "$GOROOT" = "" ] && _panic "GOROOT not set"
 	GOARCH=$(uname -m)
 	[[ $GOARCH == aarch64 ]] && GOARCH=arm64
-	echo "Installing Golang v$version... to $GOROOT"
+	[[ $GOARCH == x86_64 ]] && GOARCH=amd64
+	url=https://dl.google.com/go/go"$version".linux-"$GOARCH".tar.gz
+	echo "Installing Golang ($url)... to $GOROOT"
 	curl -L \
 		-o go.tar.gz \
-		https://dl.google.com/go/go"$version".linux-"$GOARCH".tar.gz
+		"$url"
 	mkdir -p "$GOPATH"/bin
 	mkdir -p "$GOROOT"
 	tar -C "$GOROOT/.." -xzf go.tar.gz


### PR DESCRIPTION
@samveen It looks like we need to switch out the architecture name for every `uname -m`. Does that seem right?