### PR TITLE
remove unnecessary RUN command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN install_packages \
       bzip2
 
 # Helper scripts
-RUN mkdir /build
 WORKDIR /build
 ADD .git .git
 ADD .github .github


### PR DESCRIPTION
WORKDIR already runs "mkdir -p" under the hood, so we don't need to add this extra command (and layer) to the Dockerfile.