### PR TITLE
hotfix docker build on clean env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 ENV BASE=$GOPATH/src/browsh/interfacer
 ADD interfacer $BASE
 WORKDIR $BASE
+RUN chmod +x /build/ctl.sh
 RUN /build/ctl.sh install_golang $BASE
+#todo replace with actual build of extension
+RUN curl -L -o "$BASE/src/browsh/browsh.xpi" "https://github.com/browsh-org/browsh/releases/download/v1.8.2/browsh-1.8.2.xpi"
 RUN /build/ctl.sh build_browsh_binary $BASE
 
 ###########################


### PR DESCRIPTION
Hello!
Currently it is not possible to just clone repo and run `docker build . -t browsh`.
This is not an actual pull request I'm only show you the changes which I have to make to make thinks works.
Thanks!