### PR TITLE
feat: Use log/slog for logging to file or stdout

### DIFF
--- a/SETUP_DEV_OSX.md
+++ b/SETUP_DEV_OSX.md
@@ -1,90 +1,88 @@
 # How to setup Browsh's build system for Mac
-If you just want to try Browsh, you can use [Homebrew](https://brew.sh/) (check out the [installation page](https://www.brow.sh/docs/installation/) at the [official site](https://www.brow.sh/)).
+
+If you want to try Browsh, you can use [Homebrew](https://brew.sh/).
+Check out the [installation page](https://www.brow.sh/docs/installation/) at the
+[official site](https://www.brow.sh/)).
 
 ## Installations
+
 You need Go, Firefox and Node.js to run Browsh.
 
 ### Install Go
+
 Follow the [installation guide](https://golang.org/doc/install) (you can use an installer).
 
-#### Ensure your GOPATH is set
-
-```sh
-$ echo $GOPATH
-/Users/uesr_name/go
-$ # anywhere is ok, but make sure it's not none
-```
-
-#### Ensure you have `$GOPATH/src` and `$GOPATH/bin` folders
-If you're not sure if you have these folders, run:
-
-```sh
-$ mkdir "$GOPATH/src"
-$ mkdir "$GOPATH/bin"
-```
-
 ### Install Firefox
-Follow the official [guide](https://support.mozilla.org/en-US/kb/how-download-and-install-firefox-mac) to install Firefox.
+
+Follow the official [guide](https://support.mozilla.org/en-US/kb/how-download-and-install-firefox-mac)
+to install Firefox.
 
 #### Include Firefox to your PATH
-The `firefox` executable is probably at `/Applications/Firefox.app/Contents/MacOS`. You need to add it to your `PATH` so that Browsh can create new instances of Firefox.
+
+The `firefox` executable is probably at `/Applications/Firefox.app/Contents/MacOS`.
+You need to add it to your `PATH` so that Browsh can create new instances of Firefox.
 
 ### Install Node.js
+
 Follow the [official downloading page](https://nodejs.org/en/download/).
 
-> v8.11.4. is currently recommended for working with Browsh (?)
+Use Nodejs > v8.11.4 with Browsh.
 
 #### Install web-ext globally
-It's a Mozilla's handy tool for working with Firefox web extensions:
 
-```sh
-$ npm install -g web-ext
+It's a Mozilla tool for working with Firefox web extensions:
+
+```shell
+npm install -g web-ext
 ```
 
 ## Setting up your Browsh
 
 ### Clone Browsh
-Fork Browsh to your Github account. Clone it to `$GOPATH/src`.
+
+Fork Browsh to your Github account.
+Clone it to a directory of your choice.
+We will refer to this directory as `$browsh` for the rest of the guide.
 
 ### Install NPM packages
 
 ```shell
-$ cd "$GOPATH/src/browsh/webext"
-$ npm install
+cd "$browsh/webext"
+npm install
 ```
 
 ### Run the build script
 
 ```sh
-$ cd "$GOPATH/src/browsh"
-$ # install several required package"
-$ ./interfacer/contrib/build_browsh.sh
+cd "$browsh"
+# install required package"
+./interfacer/contrib/build_browsh.sh
 ```
 
 ## Running Browsh from source
-Now that you have all of the required dependencies installed, we can run Browsh. Open three terminals and do the follows:
+
+Now that you have the required dependencies installed, we can run Browsh.
+Open three terminals and do the following:
 
 ### Terminal 1 (builds JavaScript)
 
 ```sh
-$ cd "$GOPATH/src/browsh/webext"
-$ # create a dist folder inside the webext folder.
-$ npx webpack --watch
+cd "$browsh/webext
+# create a dist folder inside the webext folder.
+npx webpack --watch
 ```
 
 ### Terminal 2 (handles Firefox web extension)
 
 ```sh
-$ # the dist folder is created in the first terminal
-$ cd "$GOPATH/src/browsh/webext/dist"
-$ # create a dist folder inside the webext folder.
-$ npx webpack --watch
+mkdir "$browsh/webext/dist"
+cd "$browsh/webext/dist"
+npx webpack --watch
 ```
 
 ### Terminal 3 (Displays Browsh)
 
 ```sh
-$ cd "$GOPATH/src/browsh/interfacer"
-$ go run ./cmd/browsh/main.go --firefox.use-existing --debug
+cd "$browsh/interfacer"
+go run ./cmd/browsh/main.go --firefox.use-existing --debug
 ```
-

--- a/interfacer/go.mod
+++ b/interfacer/go.mod
@@ -1,6 +1,6 @@
 module github.com/browsh-org/browsh/interfacer
 
-go 1.18
+go 1.21
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1

--- a/interfacer/go.sum
+++ b/interfacer/go.sum
@@ -58,6 +58,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
@@ -98,6 +99,7 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -110,6 +112,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -143,9 +146,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
@@ -164,6 +169,7 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
@@ -182,6 +188,7 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0 h1:Xuk8ma/ibJ1fOy4Ee11vHhUFHQNpHhrBneOCNHVXS5w=
 github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0/go.mod h1:7AwjWCpdPhkSmNAgUv5C7EJ4AbmjEB3r047r3DXWu3Y=
 github.com/spf13/afero v1.9.0 h1:sFSLUHgxdnN32Qy38hK3QkYBFXZj9DKjVjCUCtD7juY=
@@ -506,6 +513,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/interfacer/src/browsh/config.go
+++ b/interfacer/src/browsh/config.go
@@ -3,6 +3,7 @@ package browsh
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +16,7 @@ import (
 var (
 	configFilename = "config.toml"
 
-	isDebug   = pflag.Bool("debug", false, "Log to ./debug.log")
+	isDebug   = pflag.Bool("debug", false, "slog.Info to ./debug.log")
 	timeLimit = pflag.Int("time-limit", 0, "Kill Browsh after the specified number of seconds")
 	_         = pflag.Bool("http-server-mode", false, "Run as an HTTP service")
 
@@ -79,20 +80,18 @@ func setDefaults() {
 func loadConfig() {
 	dir := getConfigDir()
 	fullPath := filepath.Join(dir, configFilename)
-	Log("Looking in " + fullPath + " for config.")
+	slog.Info("Looking in " + fullPath + " for config.")
 	viper.SetConfigType("toml")
 	viper.SetConfigName(strings.Trim(configFilename, ".toml"))
 	viper.AddConfigPath(dir)
 	viper.AddConfigPath(".")
 	setDefaults()
 	// First load the sample config in case the user hasn't updated any new fields
-	err := viper.ReadConfig(bytes.NewBuffer([]byte(configSample)))
-	if err != nil {
+	if err := viper.ReadConfig(bytes.NewBuffer([]byte(configSample))); err != nil {
 		panic(fmt.Errorf("Config file error: %s \n", err))
 	}
 	// Then load the users own config file, overwriting the sample config
-	err = viper.MergeInConfig()
-	if err != nil {
+	if err := viper.MergeInConfig(); err != nil {
 		panic(fmt.Errorf("Config file error: %s \n", err))
 	}
 	viper.BindPFlags(pflag.CommandLine)

--- a/interfacer/src/browsh/firefox_windows.go
+++ b/interfacer/src/browsh/firefox_windows.go
@@ -4,6 +4,7 @@ package browsh
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -46,13 +47,13 @@ func getWindowsFirefoxVersionString() string {
 		Shutdown(errors.New("Error reading Windows registry: " + fmt.Sprintf("%s", err)))
 	}
 
-	Log("Windows registry Firefox version: " + versionString)
+	slog.Info("Windows registry Firefox version: " + versionString)
 
 	return versionString
 }
 
 func getFirefoxFlavor() string {
-	var flavor = "null"
+	flavor := "null"
 	k, err := registry.OpenKey(
 		registry.LOCAL_MACHINE,
 		`Software\Mozilla\Mozilla Firefox`,

--- a/interfacer/src/browsh/frame_builder.go
+++ b/interfacer/src/browsh/frame_builder.go
@@ -3,6 +3,7 @@ package browsh
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"unicode"
 
 	"github.com/gdamore/tcell"
@@ -78,7 +79,9 @@ func parseJSONFrameText(jsonString string) {
 		Shutdown(err)
 	}
 	if !isTabPresent(incoming.Meta.TabID) {
-		Log(fmt.Sprintf("Not building frame for non-existent tab ID: %d", incoming.Meta.TabID))
+		slog.Info(
+			fmt.Sprintf("Not building frame for non-existent tab ID: %d", incoming.Meta.TabID),
+		)
 		return
 	}
 	Tabs[incoming.Meta.TabID].frame.buildFrameText(incoming)
@@ -100,7 +103,9 @@ func parseJSONFramePixels(jsonString string) {
 		Shutdown(err)
 	}
 	if !isTabPresent(incoming.Meta.TabID) {
-		Log(fmt.Sprintf("Not building frame for non-existent tab ID: %d", incoming.Meta.TabID))
+		slog.Info(
+			fmt.Sprintf("Not building frame for non-existent tab ID: %d", incoming.Meta.TabID),
+		)
 		return
 	}
 	if len(Tabs[incoming.Meta.TabID].frame.text) == 0 {
@@ -139,7 +144,7 @@ func (f *frame) resetCells() {
 
 func (f *frame) isIncomingFrameTextValid(incoming incomingFrameText) bool {
 	if len(incoming.Text) == 0 {
-		Log("Not parsing zero-size text frame")
+		slog.Info("Not parsing zero-size text frame")
 		return false
 	}
 	return true
@@ -224,7 +229,7 @@ func (f *frame) populateFramePixels(incoming incomingFramePixels) {
 
 func (f *frame) isIncomingFramePixelsValid(incoming incomingFramePixels) bool {
 	if len(incoming.Colours) == 0 {
-		Log("Not parsing zero-size text frame")
+		slog.Info("Not parsing zero-size text frame")
 		return false
 	}
 	return true

--- a/interfacer/src/browsh/raw_text_server.go
+++ b/interfacer/src/browsh/raw_text_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -69,7 +70,7 @@ func HTTPServerStart() {
 	IsHTTPServerMode = true
 	StartFirefox()
 	go startWebSocketServer()
-	Log("Starting Browsh HTTP server")
+	slog.Info("Starting Browsh HTTP server")
 	bind := viper.GetString("http-server.bind")
 	port := viper.GetString("http-server.port")
 	serverMux := http.NewServeMux()
@@ -120,7 +121,7 @@ func (h *slashFix) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func handleHTTPServerRequest(w http.ResponseWriter, r *http.Request) {
 	var message string
 	var isErrored bool
-	var start = time.Now().Format(time.RFC3339)
+	start := time.Now().Format(time.RFC3339)
 	urlForBrowsh, _ := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/"))
 	urlForBrowsh, isErrored = deRecurseURL(urlForBrowsh)
 	if isErrored {
@@ -147,7 +148,7 @@ func handleHTTPServerRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	Log(r.Header.Get("User-Agent"))
+	slog.Info(r.Header.Get("User-Agent"))
 	if isKubeReadinessProbe(r.Header.Get("User-Agent")) {
 		io.WriteString(w, "healthy")
 		return
@@ -228,7 +229,7 @@ func isProductionHTTP(r *http.Request) bool {
 // 'HTML' mode returns some basic HTML tags for things like anchor links.
 // 'DOM' mode returns a simple dump of the DOM.
 func getRawTextMode(r *http.Request) string {
-	var mode = "HTML"
+	mode := "HTML"
 	if strings.Contains(r.Host, "text.") {
 		mode = "PLAIN"
 	}

--- a/interfacer/src/browsh/ui.go
+++ b/interfacer/src/browsh/ui.go
@@ -1,20 +1,20 @@
 package browsh
 
 import (
+	"log/slog"
+
 	"github.com/gdamore/tcell"
 	"github.com/spf13/viper"
 )
 
-var (
-	urlInputBox = inputBox{
-		X:        0,
-		Y:        1,
-		Height:   1,
-		text:     nil,
-		FgColour: [3]int32{255, 255, 255},
-		bgColour: [3]int32{-1, -1, -1},
-	}
-)
+var urlInputBox = inputBox{
+	X:        0,
+	Y:        1,
+	Height:   1,
+	text:     nil,
+	FgColour: [3]int32{255, 255, 255},
+	bgColour: [3]int32{-1, -1, -1},
+}
 
 // Render tabs, URL bar, status messages, etc
 func renderUI() {
@@ -28,7 +28,7 @@ func renderUI() {
 func writeString(x, y int, str string, style tcell.Style) {
 	xOriginal := x
 	if viper.GetBool("http-server-mode") {
-		Log(str)
+		slog.Info(str)
 		return
 	}
 	for _, c := range str {

--- a/interfacer/test/http-server/setup.go
+++ b/interfacer/test/http-server/setup.go
@@ -2,18 +2,20 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo"
-
 	"github.com/browsh-org/browsh/interfacer/src/browsh"
+	ginkgo "github.com/onsi/ginkgo"
 	"github.com/spf13/viper"
 )
 
-var staticFileServerPort = "4444"
-var rootDir = browsh.Shell("git rev-parse --show-toplevel")
+var (
+	staticFileServerPort = "4444"
+	rootDir              = browsh.Shell("git rev-parse --show-toplevel")
+)
 
 func startStaticFileServer() {
 	serverMux := http.NewServeMux()
@@ -59,7 +61,7 @@ func getPath(path string, mode string) string {
 		panic(fmt.Sprintf("%s", err))
 	} else {
 		defer response.Body.Close()
-		contents, err := ioutil.ReadAll(response.Body)
+		contents, err := io.ReadAll(response.Body)
 		if err != nil {
 			fmt.Printf("%s", err)
 			panic(fmt.Sprintf("%s", err))
@@ -78,9 +80,9 @@ var _ = ginkgo.BeforeEach(func() {
 	browsh.ResetTabs()
 	waitUntilConnectedToWebExtension(15 * time.Second)
 	browsh.IsMonochromeMode = false
-	browsh.Log("\n---------")
-	browsh.Log(ginkgo.CurrentGinkgoTestDescription().FullTestText)
-	browsh.Log("---------")
+	slog.Info("\n---------")
+	slog.Info(ginkgo.CurrentGinkgoTestDescription().FullTestText)
+	slog.Info("---------")
 })
 
 var _ = ginkgo.BeforeSuite(func() {


### PR DESCRIPTION
Switched to Go1.21 to use the log/slog package for strutctured logging.

TODO: Log messages that are stringifying objects can now use strutctured output.

TODO: Customise log levels for different messages.