### PR TITLE
fix: If debug is false discard logs

### DIFF
--- a/interfacer/src/browsh/browsh.go
+++ b/interfacer/src/browsh/browsh.go
@@ -3,6 +3,7 @@ package browsh
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/url"
 	"os"
@@ -44,7 +45,7 @@ var (
 )
 
 func setupLogging() {
-	out := os.Stderr
+	out := io.Discard
 	if *isDebug {
 		dir, err := os.Getwd()
 		if err != nil {


### PR DESCRIPTION
The slog change logged to stderr if debug was false. This screwed up the UI.