### PR TITLE
[Fix] Firefox inspecting logic on Windows

### DIFF
--- a/interfacer/src/browsh/firefox_windows.go
+++ b/interfacer/src/browsh/firefox_windows.go
@@ -44,7 +44,7 @@ func getWindowsFirefoxVersionString() string {
 	}
 	defer k.Close()
 
-	versionString, _, err := k.GetStringValue("")
+	versionString, _, err := k.GetStringValue("CurrentVersion")
 	if err != nil {
 		Shutdown(fmt.Errorf("Error reading Windows registry: %w", err))
 	}

--- a/interfacer/src/browsh/firefox_windows.go
+++ b/interfacer/src/browsh/firefox_windows.go
@@ -17,7 +17,7 @@ func getFirefoxPath() string {
 
 	k, err := registry.OpenKey(
 		registry.LOCAL_MACHINE,
-		`Software\Mozilla\`+flavor+` `+versionString+`\bin`,
+		`Software\Mozilla\` + flavor + `\` + versionString + `\Main`,
 		registry.QUERY_VALUE)
 	if err != nil {
 		Shutdown(fmt.Errorf("Error reading Windows registry: %w", err))

--- a/interfacer/src/browsh/firefox_windows.go
+++ b/interfacer/src/browsh/firefox_windows.go
@@ -17,7 +17,7 @@ func getFirefoxPath() string {
 
 	k, err := registry.OpenKey(
 		registry.LOCAL_MACHINE,
-		`Software\Mozilla\` + flavor + `\` + versionString + `\Main`,
+		`Software\Mozilla\`+flavor+`\`+versionString+`\Main`,
 		registry.QUERY_VALUE)
 	if err != nil {
 		Shutdown(fmt.Errorf("Error reading Windows registry: %w", err))

--- a/interfacer/src/browsh/firefox_windows.go
+++ b/interfacer/src/browsh/firefox_windows.go
@@ -22,6 +22,8 @@ func getFirefoxPath() string {
 	if err != nil {
 		Shutdown(fmt.Errorf("Error reading Windows registry: %w", err))
 	}
+	defer k.Close()
+
 	path, _, err := k.GetStringValue("PathToExe")
 	if err != nil {
 		Shutdown(fmt.Errorf("Error reading Windows registry: %w", err))


### PR DESCRIPTION
This pull request makes following changes:

1. It seems developers should use `defer` keyword to release some resources. There's a missing `defer` action in `getFirefoxPath()` function.
2. For latest stable release of Mozilla Firefox, the registry path of key `PathToExe` is incorrect. It should be `\HKEY_LOCAL_MACHINE\Software\Mozilla\Mozilla Firefox\120.0.1 (x64 zh-CN)\Main` in my case.
3. For all version of Mozilla Firefox, the registry key name is incorrect for getting version information. It should be `CurrentVersion` instead of an empty string.

- Related https://github.com/browsh-org/browsh/issues/501