### PR TITLE
Docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ ENV BASE=$GOPATH/src/browsh/interfacer
 ADD interfacer $BASE
 WORKDIR $BASE
 RUN /build/ctl.sh install_golang $BASE
+RUN wget -P "$BASE" "https://github.com/browsh-org/browsh/releases/download/v1.8.3/browsh-1.8.3.xpi"
+RUN mv "$BASE/browsh-1.8.3.xpi" "$BASE/src/browsh/browsh.xpi"
 RUN /build/ctl.sh build_browsh_binary $BASE
 
 ###########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM bitnami/minideb:bullseye as build
 
 RUN install_packages \
       curl \
+      wget\
       ca-certificates \
       git \
       autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,12 @@ RUN install_packages \
 
 # Block ads, etc. This includes porn just because this image is also used on the
 # public SSH demo: `ssh brow.sh`.
-RUN curl \
-  -o /etc/hosts \
-  https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn-social/hosts
+#RUN curl \
+#  -o /etc/hosts \
+#  https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn-social/hosts
+
+RUN echo 'curl -o /etc/hosts https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn-social/hosts' >> /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Don't use root
 RUN useradd -m user --home /app
@@ -80,5 +83,6 @@ RUN TERM=xterm script \
   >/dev/null & \
   sleep 10
 
+ENTRYPOINT ["/entrypoint.sh"]
 ENTRYPOINT ["/app/bin/browsh"]
 

--- a/scripts/misc.bash
+++ b/scripts/misc.bash
@@ -54,7 +54,8 @@ function install_golang() {
 	GOARCH=$(uname -m)
 	[[ $GOARCH == aarch64 ]] && GOARCH=arm64
 	[[ $GOARCH == x86_64 ]] && GOARCH=amd64
-	url=https://dl.google.com/go/go"$version".linux-"$GOARCH".tar.gz
+	#url=https://dl.google.com/go/go"$version".linux-"$GOARCH".tar.gz
+ 	https://go.dev/dl/go"$version".8.linux-"$GOARCH".tar.gz
 	echo "Installing Golang ($url)... to $GOROOT"
 	curl -L \
 		-o go.tar.gz \

--- a/scripts/misc.bash
+++ b/scripts/misc.bash
@@ -55,7 +55,7 @@ function install_golang() {
 	[[ $GOARCH == aarch64 ]] && GOARCH=arm64
 	[[ $GOARCH == x86_64 ]] && GOARCH=amd64
 	#url=https://dl.google.com/go/go"$version".linux-"$GOARCH".tar.gz
- 	https://go.dev/dl/go"$version".8.linux-"$GOARCH".tar.gz
+ 	url=https://go.dev/dl/go"$version".8.linux-"$GOARCH".tar.gz
 	echo "Installing Golang ($url)... to $GOROOT"
 	curl -L \
 		-o go.tar.gz \


### PR DESCRIPTION
When i tried to browsh on my linux server with Debian bullseye OS, it kept failing. I started look into the problem one by one, which I realized: 
1) the golang download page has moved to other url, so I made changes accordingly
2) the browsh.xpi is missing, as it has been noted in a few issues
3) the /etc/hosts is not modifiable during the image build, so I change it at the run point 

Here are a few drawbacks which is left for future fixes:
1) golang minor version is hardcoded 
2) I let the docker download the most recent browsh.xpi where the version is hard coded.

