### PR TITLE
fix: fixes #198 darwin should switch to monochrome mode

### DIFF
--- a/interfacer/src/browsh/tty.go
+++ b/interfacer/src/browsh/tty.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/gdamore/tcell"
@@ -78,7 +79,7 @@ func handleUserKeyPress(ev *tcell.EventKey) {
 			sendMessageToWebExtension("/tab_command,/history_back")
 		}
 	}
-	if ev.Rune() == 'm' && ev.Modifiers() == 4 {
+	if ev.Rune() == 'm' && ev.Modifiers() == 4 || (runtime.GOOS == "darwin" && ev.Rune() == 'µ') {
 		toggleMonochromeMode()
 	}
 	if ev.Key() == 279 && ev.Modifiers() == 0 {

--- a/interfacer/test/tty/tty_test.go
+++ b/interfacer/test/tty/tty_test.go
@@ -197,6 +197,13 @@ var _ = Describe("Showing a basic webpage", func() {
 			Expect([3]int32{255, 255, 255}).To(Equal(GetFgColour(12, 11)))
 		})
 
+		It("darwin should switch to monochrome mode", func() {
+			simScreen.InjectKey(tcell.KeyRune, 'µ', 0)
+			waitForNextFrame()
+			Expect([3]int32{0, 0, 0}).To(Equal(GetBgColour(0, 2)))
+			Expect([3]int32{255, 255, 255}).To(Equal(GetFgColour(12, 11)))
+		})
+
 		Describe("Text positioning", func() {
 			It("should position the left/right-aligned coloumns", func() {
 				Expect("Smörgåsbord▄(Swedish:").To(BeInFrameAt(12, 10))


### PR DESCRIPTION
```
go test -v -p 1 ./test/tty -ginkgo.focus monochrome
```

```
=== RUN   TestIntegration
Running Suite: Integration tests
================================
Random Seed: 1744924125
Will run 2 of 20 specs

SSSSSSSSSSSSSSSSS
------------------------------
• [SLOW TEST:7.386 seconds]
Showing a basic webpage
browsh/interfacer/test/tty/tty_test.go:16
  Rendering
  browsh/interfacer/test/tty/tty_test.go:166
    should switch to monochrome mode
    browsh/interfacer/test/tty/tty_test.go:193
------------------------------
• [SLOW TEST:7.377 seconds]
Showing a basic webpage
browsh/interfacer/test/tty/tty_test.go:16
  Rendering
  browsh/interfacer/test/tty/tty_test.go:166
    darwin should switch to monochrome mode
    browsh/interfacer/test/tty/tty_test.go:200
------------------------------
S
Ran 2 of 20 Specs in 24.916 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 18 Skipped
--- PASS: TestIntegration (24.92s)
PASS
ok  	github.com/browsh-org/browsh/interfacer/test/tty	25.357s
```